### PR TITLE
Address must be urlencoded

### DIFF
--- a/src/embedGoogleMapParameters.php
+++ b/src/embedGoogleMapParameters.php
@@ -2,8 +2,8 @@
 /**
 * @version		$Id: Embed Google Map v2.0.1 2015-03-28 16:06 $
 * @package		Joomla 1.6
-* @copyright	Copyright (C) 2014-2015 Petteri Kivimäki. All rights reserved.
-* @author		Petteri Kivimäki
+* @copyright	Copyright (C) 2014-2015 Petteri KivimÃ¤ki. All rights reserved.
+* @author		Petteri KivimÃ¤ki
 * Joomla! is free software. This version may have been modified pursuant
 * to the GNU General Public License, and as distributed it includes or
 * is derivative of works licensed under the GNU General Public License or
@@ -46,7 +46,7 @@
     }
 	
     public function setAddress($value) {
-      $this->address = $value;
+      $this->address = urlencode($value);
     }
 
     public function getAddress() {


### PR DESCRIPTION
With the address used in this snippet:

`{google_map}Brighton, Brighton & Hove, United Kingdom{/google_map}`

This is the given **src** value for the iframe:

`https://www.google.com/maps?q=Brighton, Brighton &amp; Hove, Regno Unito&amp;z=14&amp;t=m&amp;output=embed`

![now](https://cloud.githubusercontent.com/assets/346224/8352118/0d813d40-1b33-11e5-9c6c-d891ac492462.PNG)

The ampersand in the address is interpreted as new query separator. The address passed to the url must be urlencoded as that:

`https://www.google.com/maps?q=Brighton%2C+Brighton+%26amp%3B+Hove%2C+Regno+Unito&amp;z=14&amp;t=m&amp;output=embed`

![urlencoded](https://cloud.githubusercontent.com/assets/346224/8352125/15b2c47a-1b33-11e5-84b1-dbb61c099173.PNG)
